### PR TITLE
Hotfix Azure CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,8 @@ RUN apk update --no-cache \
   && addgroup -S -g 1001 jenkins \
   && adduser -S -D -G jenkins -u 1001 jenkins \
   && mkdir -p /opt/jenkins \
-  && chown jenkins:jenkins /opt/jenkins
+  && chown jenkins:jenkins /opt/jenkins \
+# TODO remove hotfix after mitigated / patched by Azure, see https://github.com/Azure/azure-cli/pull/17509
+  && curl https://raw.githubusercontent.com/Azure/azure-cli/fix-managed_by_tenants/src/azure-cli-core/azure/cli/core/_profile.py --output /usr/local/lib/python3.6/site-packages/azure/cli/core/_profile.py
+
 


### PR DESCRIPTION
https://github.com/Azure/azure-cli/pull/17509

`managed_by_tenants` is responding with empty which is breaking the Azure CLI

An API change by made which broke this, product group has:

1. provided a PR to fix Azure CLI
2. working on a global fix

This hotfix will allow us to work in the meantime


----

Product group said:

> This PR is only a workaround for an ongoing ARM incident (tracked by IcM 234164333). The ARM service > team is investigating with highest priority.
> We will close this PR once ARM service is fixed.